### PR TITLE
Outdated info on how to zoom Text Only

### DIFF
--- a/index.html
+++ b/index.html
@@ -850,7 +850,7 @@ figcaption {
                do one of the following <em>(depending on your browser) </em>
                <ul>
                   <li> select View &gt; Zoom &gt; Zoom Text Only. Or, with the keyboard in Firefox: Alt+V, Z, T</li>
-                  <li>select View &gt; Zoom Text Only. Or, with the keyboard in Safari: control+F2, V,  return, ZZ</li>
+                  <li>select View &gt; Zoom Text Only (hold down the Option-key if you do not see this option). Or, with the keyboard in Safari: control+F2, V,  return, ZZ</li>
                </ul>
             </li>
             <li>Incrementally increase text-only zoom:


### PR DESCRIPTION
Following info on https://www.w3.org/WAI/eval/preliminary#resize is outdated:

To check text-only zoom in Firefox, Safari, and some other browserscollapse this section
	• From the menubar, do one of the following (depending on your browser) 
		• select View > Zoom > Zoom Text Only. Or, with the keyboard in Firefox: Alt+V, Z, T
		• select View > Zoom Text Only. Or, with the keyboard in Safari: control+F2, V, return, ZZ

Actually, in Safari you need to hold down the option-key in order to see the 'Zoom text only' option. 
See https://discussions.apple.com/thread/7708319?start=0&tstart=0